### PR TITLE
Enable Travis build for G++(8,9), Clang (7,8,9) and AppleClang (10.3, 11.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,10 +130,9 @@ install:
     LLVM_INSTALL=${DEPS_DIR}/llvm/install
     # if in linux and compiler clang and llvm not installed
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "${CXX%%+*}" == "clang" && -n "$(ls -A ${LLVM_INSTALL})" ]]; then
-      if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
-      elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
-      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
+      if   [[ "${CXX}" == "clang++-7" ]];   then LLVM_VERSION="7.0.1";
+      elif [[ "${CXX}" == "clang++-8" ]];   then LLVM_VERSION="8.0.1";
+      elif [[ "${CXX}" == "clang++-9" ]];   then LLVM_VERSION="9.0.1";
       fi
       LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
       LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,41 +39,40 @@ matrix:
     # Clang on Linux
     ##########################################################################
 
-    # Clang 4.0
-    - env: COMPILER=clang++-4.0 BUILD_TYPE=Debug 
-      addons: &clang40
+    # Clang 7.0
+    - env: COMPILER=clang++-7 BUILD_TYPE=Debug
+      addons: &clang70
         apt:
           packages:
-            - clang-4.0
-            - g++-5
+            - clang-7
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-
-    # Clang 5.0
-    - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug 
-      addons: &clang50
-        apt:
-          packages:
-            - clang-5.0
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
+            - llvm-toolchain-trusty-7
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
 
-    # Clang 6.0
-    - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug 
-      addons: &clang60
+    # Clang 8.0
+    - env: COMPILER=clang++-8 BUILD_TYPE=Debug
+      addons: &clang80
         apt:
           packages:
-            - clang-6.0
-            - g++-7
+            - clang-8
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
+            - llvm-toolchain-bionic-8
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+
+    # Clang 9.0
+    - env: COMPILER=clang++-9 BUILD_TYPE=Debug
+      addons: &clang90
+        apt:
+          packages:
+            - clang-9
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-9
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
 
     ##########################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
     ##########################################################################
 
     # XCode 10.3
-    - env: COMPILER=clang++ BUILD_TYPE=Debug COVERAGE=1
+    - env: COMPILER=clang++ BUILD_TYPE=Debug
       os: osx
       osx_image: xcode10.3
       language: generic
       compiler: clang
 
     # XCode 11.2
-    - env: COMPILER=clang++ BUILD_TYPE=Debug COVERAGE=1
+    - env: COMPILER=clang++ BUILD_TYPE=Debug
       os: osx
       osx_image: xcode11.2
       language: generic
@@ -56,8 +56,6 @@ matrix:
         apt:
           packages:
             - clang-8
-            - libstdc++-8-dev
-            - libc++abi-8-dev
           sources:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
@@ -69,8 +67,6 @@ matrix:
         apt:
           packages:
             - clang-9
-            - libstdc++-9-dev
-            - libc++abi-9-dev
           sources:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
@@ -79,14 +75,6 @@ matrix:
     ##########################################################################
     # GCC on Linux
     ##########################################################################
-
-    # GCC 7
-    - env: COMPILER=g++-7 BUILD_TYPE=Debug
-      addons: &gcc7
-        apt:
-          packages: g++-7
-          sources:
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     # GCC 8
     - env: COMPILER=g++-8 BUILD_TYPE=Debug
@@ -106,14 +94,7 @@ matrix:
           sources:
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
-# Added following instructions from https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
 before_install:
-  - |
-     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-       sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-       sudo apt-get update -q
-       sudo apt-get install gcc-4.8 -y
-     fi
 
 install:
   # Set the ${CXX} variable properly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 
 # Use Linux unless specified otherwise
 os: linux
-dist: trusty
+dist: bionic
 
 cache:
   directories:
@@ -46,7 +46,7 @@ matrix:
           packages:
             - clang-7
           sources:
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,7 +168,7 @@ before_script:
   # have CMake to generate build files
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir build && cd build
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+  - cmake ../linear_algebra/code -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
 script:
   # build and run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,176 @@
+# Based on https://github.com/Microsoft/GSL/blob/master/.travis.yml
+language: cpp
+sudo: false
+notifications:
+  email: false
+
+# Use Linux unless specified otherwise
+os: linux
+dist: trusty
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/deps
+
+matrix:
+  include:
+
+    ##########################################################################
+    # Clang on OSX
+    # Travis seems to take longer to start OSX instances,
+    # so leave this first for the overall build to be faster
+    ##########################################################################
+
+    # XCode 10.3
+    - env: COMPILER=clang++ BUILD_TYPE=Debug COVERAGE=1
+      os: osx
+      osx_image: xcode10.3
+      language: generic
+      compiler: clang
+
+    # XCode 11.1
+    - env: COMPILER=clang++ BUILD_TYPE=Debug COVERAGE=1
+      os: osx
+      osx_image: xcode11.1
+      language: generic
+      compiler: clang
+
+    ##########################################################################
+    # Clang on Linux
+    ##########################################################################
+
+    # Clang 4.0
+    - env: COMPILER=clang++-4.0 BUILD_TYPE=Debug 
+      addons: &clang40
+        apt:
+          packages:
+            - clang-4.0
+            - g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+
+    # Clang 5.0
+    - env: COMPILER=clang++-5.0 BUILD_TYPE=Debug 
+      addons: &clang50
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+
+    # Clang 6.0
+    - env: COMPILER=clang++-6.0 BUILD_TYPE=Debug 
+      addons: &clang60
+        apt:
+          packages:
+            - clang-6.0
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+
+    ##########################################################################
+    # GCC on Linux
+    ##########################################################################
+
+    # GCC 5
+    - env: COMPILER=g++-5 BUILD_TYPE=Debug 
+      addons: &gcc5
+        apt:
+          packages: g++-5
+          sources:
+            - ubuntu-toolchain-r-test
+
+    # GCC 6
+    - env: COMPILER=g++-6 BUILD_TYPE=Debug 
+      addons: &gcc6
+        apt:
+          packages: g++-6
+          sources:
+            - ubuntu-toolchain-r-test
+
+    # GCC 7
+    - env: COMPILER=g++-7 BUILD_TYPE=Debug 
+      addons: &gcc7
+        apt:
+          packages: g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+# Added following instructions from https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
+before_install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -q
+  - sudo apt-get install gcc-4.8 -y
+
+install:
+  # Set the ${CXX} variable properly
+  - export CXX=${COMPILER}
+  - ${CXX} --version
+
+  # Dependencies required by the CI are installed in ${TRAVIS_BUILD_DIR}/deps/
+  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+  - mkdir -p "${DEPS_DIR}"
+  - cd "${DEPS_DIR}"
+
+  # Travis machines have 2 cores
+  - JOBS=2
+
+  ############################################################################
+  # Install a recent CMake (unless already installed on OS X)
+  ############################################################################
+  - CMAKE_VERSION=3.15.4
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+      mkdir cmake && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+    else
+      which cmake || brew install cmake || brew upgrade cmake
+    fi
+  - cmake --version
+
+  ############################################################################
+  # [linux]: Install the right version of libc++
+  ############################################################################
+  - |
+    LLVM_INSTALL=${DEPS_DIR}/llvm/install
+    # if in linux and compiler clang and llvm not installed
+    if [[ "${TRAVIS_OS_NAME}" == "linux" && "${CXX%%+*}" == "clang" && -n "$(ls -A ${LLVM_INSTALL})" ]]; then
+      if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
+      elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
+      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
+      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
+      fi
+      LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
+      LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
+      LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"
+      mkdir -p llvm llvm/build llvm/projects/libcxx llvm/projects/libcxxabi
+      travis_retry wget -O - ${LLVM_URL} | tar --strip-components=1 -xJ -C llvm
+      travis_retry wget -O - ${LIBCXX_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxx
+      travis_retry wget -O - ${LIBCXXABI_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxxabi
+      (cd llvm/build && cmake .. -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL})
+      (cd llvm/build/projects/libcxx && make install -j2)
+      (cd llvm/build/projects/libcxxabi && make install -j2)
+      export CXXFLAGS="-isystem ${LLVM_INSTALL}/include/c++/v1"
+      export LDFLAGS="-L ${LLVM_INSTALL}/lib -l c++ -l c++abi"
+      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${LLVM_INSTALL}/lib"
+    fi
+  
+before_script:
+  # have CMake to generate build files
+  - cd "${TRAVIS_BUILD_DIR}"
+  - mkdir build && cd build
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+script:
+  # build and run tests
+  - cmake --build . -- -j${JOBS}
+  - ctest --output-on-failure -j${JOBS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,12 @@ matrix:
 
 # Added following instructions from https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
 before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -q
-  - sudo apt-get install gcc-4.8 -y
+  - |
+     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+       sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+       sudo apt-get update -q
+       sudo apt-get install gcc-4.8 -y
+     fi
 
 install:
   # Set the ${CXX} variable properly

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ matrix:
       language: generic
       compiler: clang
 
-    # XCode 11.1
+    # XCode 11.2
     - env: COMPILER=clang++ BUILD_TYPE=Debug COVERAGE=1
       os: osx
-      osx_image: xcode11.1
+      osx_image: xcode11.2
       language: generic
       compiler: clang
 
@@ -80,29 +80,31 @@ matrix:
     # GCC on Linux
     ##########################################################################
 
-    # GCC 5
-    - env: COMPILER=g++-5 BUILD_TYPE=Debug 
-      addons: &gcc5
-        apt:
-          packages: g++-5
-          sources:
-            - ubuntu-toolchain-r-test
-
-    # GCC 6
-    - env: COMPILER=g++-6 BUILD_TYPE=Debug 
-      addons: &gcc6
-        apt:
-          packages: g++-6
-          sources:
-            - ubuntu-toolchain-r-test
-
     # GCC 7
-    - env: COMPILER=g++-7 BUILD_TYPE=Debug 
+    - env: COMPILER=g++-7 BUILD_TYPE=Debug
       addons: &gcc7
         apt:
           packages: g++-7
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+
+    # GCC 8
+    - env: COMPILER=g++-8 BUILD_TYPE=Debug
+      addons: &gcc8
+        apt:
+          packages:
+            - g++-8
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+
+    # GCC 9
+    - env: COMPILER=g++-9 BUILD_TYPE=Debug
+      addons: &gcc9
+        apt:
+          packages:
+            - g++-9
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
 # Added following instructions from https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,9 @@ matrix:
           packages:
             - clang-7
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
             - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     # Clang 8.0
     - env: COMPILER=clang++-8 BUILD_TYPE=Debug
@@ -58,10 +57,9 @@ matrix:
           packages:
             - clang-8
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-bionic-8
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     # Clang 9.0
     - env: COMPILER=clang++-9 BUILD_TYPE=Debug
@@ -70,10 +68,9 @@ matrix:
           packages:
             - clang-9
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-bionic-9
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
 
     ##########################################################################
     # GCC on Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ matrix:
         apt:
           packages:
             - clang-8
+            - libstdc++-8-dev
+            - libc++abi-8-dev
           sources:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
@@ -67,6 +69,8 @@ matrix:
         apt:
           packages:
             - clang-9
+            - libstdc++-9-dev
+            - libc++abi-9-dev
           sources:
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # wg21
-
+ [![Travis Build Status](https://travis-ci.org/twon/wg21.svg?branch=dev_twon_travis)](https://travis-ci.org/twon/wg21)
  [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/BobSteagall/wg21?svg=true&branch=master)](https://ci.appveyor.com/project/BobSteagall/wg21)
  


### PR DESCRIPTION
Similarly to the Appveyor changes Bob will need to activate a Travis account and enable the wg21 repository for Travis.  Once that is done I will need to update the readme file so as to point the Travis badge at the master branch on Bob's instance of the github repository.