### PR TITLE
Modern CMake and install step added

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ The linear algebra proposal is targeted for C++23.  Current compiler support is 
 * Ubuntu 18
   * GCC 8.x, 9.x
   * Clang 7.x, 8.x, 9.x 
+
+# Building Manually Via CMake
+
+The project can be build via CMake as follows:
+```bash
+cd <project root>
+mkdir build
+cd build
+
+cmake -G <generator> <configuration options> ../linear_algrbra/code
+cmake --build ../
+ctest
+```
+
+# Installing Via CMake
+
+Installing the project can be run as follows:
+```bash
+cd <project root>
+mkdir build
+cd build
+
+cmake -G <generator> <configuration options> -DCMAKE_INSTALL_PREFIX=<install dir> ../
+cmake --build ../linear_algrbra/code --target install
+```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd <project root>
 mkdir build
 cd build
 
-cmake -G <generator> <configuration options> ../linear_algrbra/code
+cmake -G <generator> <configuration options> ../linear_algebra/code
 cmake --build ../
 ctest
 ```
@@ -39,5 +39,5 @@ mkdir build
 cd build
 
 cmake -G <generator> <configuration options> -DCMAKE_INSTALL_PREFIX=<install dir> ../
-cmake --build ../linear_algrbra/code --target install
+cmake --build ../linear_algebra/code --target install
 ```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
  [![Travis Build Status](https://travis-ci.org/BobSteagall/wg21.svg?branch=master)](https://travis-ci.org/BobSteagall/wg21)
  [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/BobSteagall/wg21?svg=true&branch=master)](https://ci.appveyor.com/project/BobSteagall/wg21)
  
+# Support
+
+The linear algebra proposal is targeted for C++23.  Current compiler support is as follows but is liable to change as compilers catch up with implementing new language features.
+
+* Windows
+  * Visual Studio 2019
+
+* Mac OS
+  * macOS 10.14, Xcode 10.3
+  * macOS 10.14, Xcode 11.2
+
+* Ubuntu 18
+  * GCC 8.x, 9.x
+  * Clang 7.x, 8.x, 9.x 

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -114,7 +114,7 @@ include(GNUInstallDirs)
 # Hierarchically copy headers to the install dir
 install (
     DIRECTORY
-        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra"
     DESTINATION
         ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(wg21_linear_algebra)
+project(wg21_linear_algebra VERSION 0.0.1)
 
 include(CTest)
 
@@ -109,4 +109,53 @@ target_compile_options(la_test
 # This should be passed in via the commmand line ("cmake --build ./ -v" or "cmake --build ./ -DCMAKE_VERBOSE_MAKEFILE=1")
 #set(CMAKE_VERBOSE_MAKEFILE 1)
 
+include(GNUInstallDirs)
 
+# Hierarchically copy headers to the install dir
+install (
+    DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    DESTINATION
+        ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN
+        "*.hpp"
+)
+
+install(
+    TARGETS wg21_linear_algebra
+    DESTINATION lib/cmake/wg21_linear_algebra
+    EXPORT wg21_linear_algebra-target
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(
+    EXPORT wg21_linear_algebra-target
+    NAMESPACE wg21_linear_algebra::
+    #FILE wg21_linear_algebra-target.cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/wg21_linear_algebra"
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/wg21_linear_algebra-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/wg21_linear_algebra-config.cmake
+    INSTALL_DESTINATION
+        "${CMAKE_INSTALL_LIBDIR}/cmake/wg21_linear_algebra"
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/wg21_linear_algebra-version.cmake
+    VERSION ${PROPAGATE_CONST_VERSION}
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/wg21_linear_algebra-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/wg21_linear_algebra-version.cmake
+    DESTINATION
+        "${CMAKE_INSTALL_LIBDIR}/cmake/wg21_linear_algebra"
+)

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -1,54 +1,107 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(wg21_linear_algebra)
 
 include(CTest)
 
-set(Includes
-    include/linear_algebra.hpp
-    include/linear_algebra/addition_traits.hpp
-    include/linear_algebra/addition_traits_impl.hpp
-    include/linear_algebra/arithmetic_operators.hpp
-    include/linear_algebra/arithmetic_traits.hpp
-    include/linear_algebra/debug_helpers.hpp
-    include/linear_algebra/dynamic_engines.hpp
-    include/linear_algebra/engine_traits.hpp
-    include/linear_algebra/fixed_size_engines.hpp
-    include/linear_algebra/forward_declarations.hpp
-    include/linear_algebra/library_aliases.hpp
-    include/linear_algebra/matrix.hpp
-    include/linear_algebra/multiplication_traits.hpp
-    include/linear_algebra/multiplication_traits_impl.hpp
-    include/linear_algebra/negation_traits.hpp
-    include/linear_algebra/negation_traits_impl.hpp
-    include/linear_algebra/number_traits.hpp
-    include/linear_algebra/operation_traits.hpp
-    include/linear_algebra/row_column_views.hpp
-    include/linear_algebra/subtraction_traits.hpp
-    include/linear_algebra/subtraction_traits_impl.hpp
-    include/linear_algebra/transpose_views.hpp
-    include/linear_algebra/vector.hpp
-
-    test/test_new_arithmetic.hpp
-    test/test_new_engine.hpp
-    test/test_new_number.hpp
+add_library(wg21_linear_algebra INTERFACE)
+target_include_directories(wg21_linear_algebra
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
 )
 
-set(Sources
-    test/test_obj_matrix.cpp
-    test/test_op_add.cpp
-    test/test_op_mul.cpp
-    test/test_op_neg.cpp
-    test/test_op_sub.cpp
-#    test/test_01.cpp
-#    test/test_02.cpp
-    test/test_main.cpp
+target_sources(wg21_linear_algebra
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/addition_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/addition_traits_impl.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/arithmetic_operators.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/arithmetic_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/debug_helpers.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/dynamic_engines.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/engine_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/fixed_size_engines.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/forward_declarations.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/library_aliases.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/matrix.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/multiplication_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/multiplication_traits_impl.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/negation_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/negation_traits_impl.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/number_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/operation_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/row_column_views.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/subtraction_traits.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/subtraction_traits_impl.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/transpose_views.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra/vector.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/addition_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/addition_traits_impl.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/arithmetic_operators.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/arithmetic_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/debug_helpers.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/dynamic_engines.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/engine_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/fixed_size_engines.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/forward_declarations.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/library_aliases.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/matrix.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/multiplication_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/multiplication_traits_impl.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/negation_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/negation_traits_impl.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/number_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/operation_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/row_column_views.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/subtraction_traits.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/subtraction_traits_impl.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/transpose_views.hpp>
+        $<INSTALL_INTERFACE:include/linear_algebra/vector.hpp>
 )
 
-include_directories(include test .)
+target_compile_features(wg21_linear_algebra
+    INTERFACE
+        cxx_std_17
+)
 
-add_executable(la_test ${Sources} ${Includes})
+add_library(wg21_linear_algebra::wg21_linear_algebra ALIAS wg21_linear_algebra)
 
-set(CMAKE_VERBOSE_MAKEFILE 1)
+add_executable(la_test "")
+
+target_include_directories(la_test
+    PRIVATE
+        test
+)
+
+target_sources(la_test
+    PRIVATE
+        test/test_new_arithmetic.hpp
+        test/test_new_engine.hpp
+        test/test_new_number.hpp
+        test/test_obj_matrix.cpp
+        test/test_op_add.cpp
+        test/test_op_mul.cpp
+        test/test_op_neg.cpp
+        test/test_op_sub.cpp
+ #       test/test_01.cpp
+ #       test/test_02.cpp
+        test/test_main.cpp
+)
+
+target_link_libraries(la_test
+    PRIVATE
+        wg21_linear_algebra::wg21_linear_algebra
+)
+
+set_target_properties(la_test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
+# This should be passed in via the commmand line ("cmake --build ./ -v" or "cmake --build ./ -DCMAKE_VERBOSE_MAKEFILE=1")
+#set(CMAKE_VERBOSE_MAKEFILE 1)
 
 if(CXX_COMPILER STREQUAL clang++)
     set(CMAKE_C_COMPILER   clang)
@@ -58,13 +111,19 @@ else()
     set(CMAKE_CXX_COMPILER g++)
 endif()
 
+target_compile_options(la_test
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:GNU>>:-Wall -pedantic -Wextra  -Wno-unused-function -Wno-unused-variable -W -Wno-unused-but-set-variable -fmax-errors=10>
+        $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Wall -pedantic -Wextra -Wno-unused-parameter -Wno§-unused-function>
+)
+
 if(CMAKE_CXX_COMPILER STREQUAL clang++)
 
     set(CMAKE_C_FLAGS_DEBUG   "-g -Wall -pedantic -Wextra")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -std=c++17 -Wall -pedantic -Wextra -Wno-unused-parameter -Wno-unused-function")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -std=c++17")
 
     set(CMAKE_C_FLAGS_RELEASE   "-O3 -march=westmere -Wall -pedantic -Wextra")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=westmere -std=c++17 -stdlib=libc++ -Wall -pedantic -Wextra -Wno-unused-parameter -Wno-unused-function")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=westmere -std=c++17 -stdlib=libc++")
 
 elseif(CMAKE_CXX_COMPILER STREQUAL g++)
 

--- a/linear_algebra/code/wg21_linear_algebra-config.cmake.in
+++ b/linear_algebra/code/wg21_linear_algebra-config.cmake.in
@@ -1,0 +1,9 @@
+  
+@PACKAGE_INIT@
+
+check_required_components(wg21_linear_algebra)
+
+if(NOT TARGET wg21_linear_algebra::wg21_linear_algebra)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    include(${CMAKE_CURRENT_LIST_DIR}/wg21_linear_algebra-target.cmake)
+endif()


### PR DESCRIPTION
Update the CMake to use the modern targets based approach to CMake.  This provides an interface target which other users can depend upon in their own project's CMake code to get the targets setting (include directory, required version of C++, compiler flags, and header files).

Additionally, this adds an install step which allows a packaged structure of the project to be produced.  This will allows automatic Zip generation of the project via CPack and will be used when we add a Conan package to generate the package internals providing numerous options for how other users can get access to this library.