### PR TITLE
Add support for the Conan Package Manager

### DIFF
--- a/.conan/build.py
+++ b/.conan/build.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import re
+import argparse
+from cpt.packager import ConanMultiPackager
+
+def username():
+    return os.getenv("CONAN_USERNAME", "public-conan")
+
+def login_username():
+    return os.getenv("CONAN_LOGIN_USERNAME", "Twonington")
+
+def upload():
+    return os.getenv("CONAN_UPLOAD", "https://api.bintray.com/conan/twonington/public-conan")
+
+def upload_only_when_stable():
+    return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", "True").lower() in ["true", "1", "yes"]
+
+def channel():
+    return os.getenv("CONAN_CHANNEL", "testing")
+
+def stable_branch_pattern():
+    return os.getenv("CONAN_STABLE_BRANCH_PATTERN", r"v\d+\.\d+\.\d+")
+
+def version():
+    version = 'latest'
+    with open(os.path.join(os.path.dirname(__file__), "..", "linear_algebra", "code", "CMakeLists.txt")) as file:
+        pattern = re.compile(r'project\(wg21_linear_algebra VERSION (\d+\.\d+\.\d+)\)')
+        for line in file:
+            result = pattern.search(line)
+            if result:
+                version = result.group(1)
+    return version
+
+def reference():
+    return os.getenv("CONAN_REFERENCE", "linear_algebra/{}".format(version()))
+
+if __name__ == "__main__":
+
+    # To call this its usual for Travis or Appveyor to set environment variables in order to either provide setting you dont want to be visible in the script (i.e. passwords)
+    # or to limit the compilers users when generating profiles (particularly for mac where usually only on apple-clang version is installed, even though the script will attempt
+    # to generate profiles for numerous.  Compiler versions can be limited as such (with VS and GCC equivalents available).
+    # CONAN_APPLE_CLANG_VERSIONS=11.0
+    # Travis and Appveyor allow for private environment variables to be defines on the project configuration setting (i.e. not via config files checking into source control).
+    # CONAN_PASSWORD=<get this from your user profile on bintray via edit profile -> API Key)
+    # Set this to upload testing branches while in development
+    # CONAN_UPLOAD_ONLY_WHEN_STABLE=0
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', default=username(), help="The name for the organisation that the linear_algebra repository belongs to.")
+    parser.add_argument('--login', default=login_username(), help="The name of a user within the organisation to upload the package under.")
+    parser.add_argument('--upload', default=upload(), help="The remote URL to upload to.")
+    parser.add_argument('--channel', default=channel(), help="The channel to upload to by default, unless the branch name matches the specified stable branch matching pattern.")
+    args = parser.parse_args()
+
+    builder = ConanMultiPackager(
+        username = args.username,
+        login_username=args.login,
+        upload=args.upload,
+        upload_only_when_stable=upload_only_when_stable(),
+        stable_branch_pattern=stable_branch_pattern(),
+        reference=reference(),
+        test_folder=os.path.join(".conan", "test_package")
+    )
+    builder.add_common_builds()
+    builder.run()

--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(wg21_linear_algebra REQUIRED)
+
+add_executable(test_linear_algebra
+        ../../linear_algebra/code/test/test_new_arithmetic.hpp
+        ../../linear_algebra/code/test/test_new_engine.hpp
+        ../../linear_algebra/code/test/test_new_number.hpp
+        ../../linear_algebra/code/test/test_obj_matrix.cpp
+        ../../linear_algebra/code/test/test_op_add.cpp
+        ../../linear_algebra/code/test/test_op_mul.cpp
+        ../../linear_algebra/code/test/test_op_neg.cpp
+        ../../linear_algebra/code/test/test_op_sub.cpp
+        #       test/test_01.cpp
+        #       test/test_02.cpp
+        ../../linear_algebra/code/test/test_main.cpp
+)
+
+target_link_libraries(test_linear_algebra PRIVATE wg21_linear_algebra::wg21_linear_algebra)

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if tools.cross_building(self.settings):
+            return
+        bin_path = os.path.join("bin", "test_linear_algebra")
+        self.run(bin_path, run_environment=True)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,161 +1,45 @@
-# Based on https://github.com/Microsoft/GSL/blob/master/.travis.yml
-language: cpp
-sudo: false
-notifications:
-  email: false
+env:
+  global:
+    - CONAN_BUILD_REQUIRES="cmake_installer/3.14.7@conan/stable, ninja/1.9.0"
+    - CONAN_CMAKE_GENERATOR=Ninja
+    - CONAN_PRINT_RUN_COMMANDS=1
 
-# Use Linux unless specified otherwise
-os: linux
-dist: bionic
-
-cache:
-  directories:
-    - ${TRAVIS_BUILD_DIR}/deps
-
+linux: &linux
+  os: linux
+  sudo: required
+  language: python
+  python: "3.6"
+  services:
+    - docker
+osx: &osx
+  os: osx
+  language: generic
 matrix:
   include:
-
-    ##########################################################################
-    # Clang on OSX
-    # Travis seems to take longer to start OSX instances,
-    # so leave this first for the overall build to be faster
-    ##########################################################################
-
-    # XCode 10.3
-    - env: COMPILER=clang++ BUILD_TYPE=Debug
-      os: osx
-      osx_image: xcode10.3
-      language: generic
-      compiler: clang
-
-    # XCode 11.2
-    - env: COMPILER=clang++ BUILD_TYPE=Debug
-      os: osx
-      osx_image: xcode11.2
-      language: generic
-      compiler: clang
-
-    ##########################################################################
-    # Clang on Linux
-    ##########################################################################
-
-    # Clang 7.0
-    - env: COMPILER=clang++-7 BUILD_TYPE=Debug
-      addons: &clang70
-        apt:
-          packages:
-            - clang-7
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
-
-    # Clang 8.0
-    - env: COMPILER=clang++-8 BUILD_TYPE=Debug
-      addons: &clang80
-        apt:
-          packages:
-            - clang-8
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
-
-    # Clang 9.0
-    - env: COMPILER=clang++-9 BUILD_TYPE=Debug
-      addons: &clang90
-        apt:
-          packages:
-            - clang-9
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
-
-    ##########################################################################
-    # GCC on Linux
-    ##########################################################################
-
-    # GCC 8
-    - env: COMPILER=g++-8 BUILD_TYPE=Debug
-      addons: &gcc8
-        apt:
-          packages:
-            - g++-8
-          sources:
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
-
-    # GCC 9
-    - env: COMPILER=g++-9 BUILD_TYPE=Debug
-      addons: &gcc9
-        apt:
-          packages:
-            - g++-9
-          sources:
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
-
-before_install:
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc9-armv7hf
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc9-armv8
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
+      # libc++ 32 bit is broken in the clang8/clang9 Docker images
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=8 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=conanio/clang8
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=9 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=conanio/clang9
+      - <<: *osx
+        osx_image: xcode10.3
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0
+      - <<: *osx
+        osx_image: xcode11.2
+        env: CONAN_APPLE_CLANG_VERSIONS=11.0
 
 install:
-  # Set the ${CXX} variable properly
-  - export CXX=${COMPILER}
-  - ${CXX} --version
-
-  # Dependencies required by the CI are installed in ${TRAVIS_BUILD_DIR}/deps/
-  - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
-  - mkdir -p "${DEPS_DIR}"
-  - cd "${DEPS_DIR}"
-
-  # Travis machines have 2 cores
-  - JOBS=2
-
-  ############################################################################
-  # Install a recent CMake (unless already installed on OS X)
-  ############################################################################
-  - CMAKE_VERSION=3.15.4
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-      mkdir cmake && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
-      export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-    else
-      which cmake || brew install cmake || brew upgrade cmake
-    fi
-  - cmake --version
-
-  ############################################################################
-  # [linux]: Install the right version of libc++
-  ############################################################################
-  - |
-    LLVM_INSTALL=${DEPS_DIR}/llvm/install
-    # if in linux and compiler clang and llvm not installed
-    if [[ "${TRAVIS_OS_NAME}" == "linux" && "${CXX%%+*}" == "clang" && -n "$(ls -A ${LLVM_INSTALL})" ]]; then
-      if   [[ "${CXX}" == "clang++-7" ]];   then LLVM_VERSION="7.0.1";
-      elif [[ "${CXX}" == "clang++-8" ]];   then LLVM_VERSION="8.0.1";
-      elif [[ "${CXX}" == "clang++-9" ]];   then LLVM_VERSION="9.0.1";
-      fi
-      LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
-      LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
-      LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"
-      mkdir -p llvm llvm/build llvm/projects/libcxx llvm/projects/libcxxabi
-      travis_retry wget -O - ${LLVM_URL} | tar --strip-components=1 -xJ -C llvm
-      travis_retry wget -O - ${LIBCXX_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxx
-      travis_retry wget -O - ${LIBCXXABI_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxxabi
-      (cd llvm/build && cmake .. -DCMAKE_INSTALL_PREFIX=${LLVM_INSTALL})
-      (cd llvm/build/projects/libcxx && make install -j2)
-      (cd llvm/build/projects/libcxxabi && make install -j2)
-      export CXXFLAGS="-isystem ${LLVM_INSTALL}/include/c++/v1"
-      export LDFLAGS="-L ${LLVM_INSTALL}/lib -l c++ -l c++abi"
-      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${LLVM_INSTALL}/lib"
-    fi
-  
-before_script:
-  # have CMake to generate build files
-  - cd "${TRAVIS_BUILD_DIR}"
-  - mkdir build && cd build
-  - cmake ../linear_algebra/code -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+  - ./.travis/install.sh
 
 script:
-  # build and run tests
-  - cmake --build . -- -j${JOBS}
-  - ctest --output-on-failure -j${JOBS}
+  - ./.travis/run.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 2.7.10
+    pyenv virtualenv 2.7.10 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install conan --upgrade
+pip install conan_package_tools==0.30.2
+
+conan user

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+python build.py

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -10,4 +10,4 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate conan
 fi
 
-python build.py
+python .conan/build.py

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ cmake --build ../
 ctest
 ```
 
+The following configuration options are available:
+
+| Name                | Possible Values | Description                             | Default Value |
+|---------------------|-----------------|-----------------------------------------|---------------|
+| `BUILD_TESTING`     | `ON`, `OFF`     | Build the test suite                    | `ON`          |
+
 # Installing Via CMake
 
 Installing the project can be run as follows:
@@ -40,4 +46,35 @@ cd build
 
 cmake -G <generator> <configuration options> -DCMAKE_INSTALL_PREFIX=<install dir> ../
 cmake --build ../linear_algebra/code --target install
+```
+
+# Packages
+
+The Linear Algebra library is available integration into your own project via your favorite package manager:
+
+## Conan
+
+To add the linear_algebra library to your project as a dependency, you need to add a remote to Conan to point the
+location of the library:
+```bash
+cd <project root>
+pip install conan
+
+conan remote add linear_algebra https://api.bintray.com/conan/twonington/public-conan
+```
+Once this is set you can add the linear_algebra dependency to you project via the following signature:
+```bash
+linear_algebra/0.0.1@public-conan/testing
+```
+Available versions of the Linear Algebra package can be search via Conan:
+```bash
+conan search linear_algebra
+```
+
+### Building the Conan package
+The linear_algebra project and package can be build locally via the Conan as such:
+```bash
+cd <project root>
+pip install conan
+conan create <project root> [--test-folder None]
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,7 @@ environment:
   CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"
-
-    matrix:
+  matrix:
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
         CONAN_VISUAL_VERSIONS: 16
         CONAN_BUILD_TYPES: Release
@@ -21,7 +20,7 @@ environment:
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
         CONAN_VISUAL_VERSIONS: 16
         CONAN_BUILD_TYPES: Debug
-        CONAN_ARCHS: x86_64
+        CONAN_ARCHS: x86
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,33 @@
-branches:
-  only:
-    - master
+build: false
 
-image:
-  - Visual Studio 2019
+environment:
+  CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
+  CONAN_PRINT_RUN_COMMANDS: 1
+  PYTHON_HOME: "C:\\Python37"
 
-clone_folder: c:\projects\wg21
+    matrix:
+      - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        CONAN_VISUAL_VERSIONS: 16
+        CONAN_BUILD_TYPES: Release
+        CONAN_ARCHS: x86_64
+      - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        CONAN_VISUAL_VERSIONS: 16
+        CONAN_BUILD_TYPES: Release
+        CONAN_ARCHS: x86
+      - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        CONAN_VISUAL_VERSIONS: 16
+        CONAN_BUILD_TYPES: Debug
+        CONAN_ARCHS: x86_64
+      - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        CONAN_VISUAL_VERSIONS: 16
+        CONAN_BUILD_TYPES: Debug
+        CONAN_ARCHS: x86_64
 
-build_script:
-  # Switch into the working directory build folder
-  - cmd: cd c:\projects\wg21
-  - cmd: mkdir build
-  - cmd: cd build
-
-  - cmd: if "%platform%" == "x64" set cmake_platform=%platform%
-  - cmd: cmake -g "Visual Studio 15 2017" ../linear_algebra/code -DCMAKE_GENERATOR_PLATFORM=%cmake_platform%
-
-  # build it
-  - cmd: cmake --build ./ -v 
+install:
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%
+  - pip.exe install conan --upgrade
+  - pip.exe install conan_package_tools
+  - conan user # It creates the conan data directory
 
 test_script:
-  - if "%configuration%" == "Debug" ctest -C Debug
+  - python .conan/build.py

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from conans import ConanFile, CMake, tools
+import os.path
+
+class LinearAlgebraConan(ConanFile):
+    name = "linear_algebra"
+    version = "0.0.1"
+    license = "MIT"
+    url = "https://github.com/BobSteagall/wg21"
+    description = "A linear algebra proposal for the C++ standard library"
+    topics = ("conan", "linear algebra", "header-only", "std", "math", "wg21")
+    exports_sources = "*.txt", "*.hpp", "*.cpp", "*.cmake", "*.cmake.in", "LICENSE.txt"
+    generators = "cmake"
+
+    _cmake = None
+    @property
+    def cmake(self):
+        if self._cmake is None:
+            self._cmake = CMake(self)
+            self._cmake.definitions.update({
+                "BUILD_TESTING": False
+            })
+            self._cmake.configure(source_folder=os.path.join("linear_algebra", "code"))
+        return self._cmake
+
+
+    def package(self):
+        self.cmake.build()
+        if self.options.build_testing:
+            self.cmake.test()
+
+    def package(self):
+        self.cmake.install()

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(wg21_linear_algebra VERSION 0.0.1)
 
-include(CTest)
-
 add_library(wg21_linear_algebra INTERFACE)
 target_include_directories(wg21_linear_algebra
     INTERFACE
@@ -65,46 +63,50 @@ target_compile_features(wg21_linear_algebra
         cxx_std_17
 )
 
-add_library(wg21_linear_algebra::wg21_linear_algebra ALIAS wg21_linear_algebra)
+if (BUILD_TESTING)
+    include(CTest)
+    add_library(wg21_linear_algebra::wg21_linear_algebra ALIAS wg21_linear_algebra)
 
-add_executable(la_test "")
+    add_executable(la_test "")
 
-target_include_directories(la_test
-    PRIVATE
-        test
-)
+    target_include_directories(la_test
+        PRIVATE
+            test
+    )
 
-target_sources(la_test
-    PRIVATE
-        test/test_new_arithmetic.hpp
-        test/test_new_engine.hpp
-        test/test_new_number.hpp
-        test/test_obj_matrix.cpp
-        test/test_op_add.cpp
-        test/test_op_mul.cpp
-        test/test_op_neg.cpp
-        test/test_op_sub.cpp
- #       test/test_01.cpp
- #       test/test_02.cpp
-        test/test_main.cpp
-)
+    target_sources(la_test
+        PRIVATE
+            test/test_new_arithmetic.hpp
+            test/test_new_engine.hpp
+            test/test_new_number.hpp
+            test/test_obj_matrix.cpp
+            test/test_op_add.cpp
+            test/test_op_mul.cpp
+            test/test_op_neg.cpp
+            test/test_op_sub.cpp
+     #       test/test_01.cpp
+     #       test/test_02.cpp
+            test/test_main.cpp
+    )
 
-target_link_libraries(la_test
-    PRIVATE
-        wg21_linear_algebra::wg21_linear_algebra
-)
+    target_link_libraries(la_test
+        PRIVATE
+            wg21_linear_algebra::wg21_linear_algebra
+    )
 
-set_target_properties(la_test PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES
-    CXX_EXTENSIONS NO
-)
+    set_target_properties(la_test PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+    )
 
-target_compile_options(la_test
-    PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:GNU>>:-Wall -pedantic -Wextra  -Wno-unused-function -Wno-unused-variable -W -Wno-unused-but-set-variable -fmax-errors=10>
-        $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Wall -pedantic -Wextra -Wno-unused-parameter -Wno-unused-function>
-)
+    target_compile_options(la_test
+        PRIVATE
+            $<$<OR:$<CXX_COMPILER_ID:GNU>>:-Wall -pedantic -Wextra  -Wno-unused-function -Wno-unused-variable -W -Wno-unused-but-set-variable -fmax-errors=10>
+            $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Wall -pedantic -Wextra -Wno-unused-parameter -Wno-unused-function>
+    )
+
+endif(BUILD_TESTING)
 
 # This should be passed in via the commmand line ("cmake --build ./ -v" or "cmake --build ./ -DCMAKE_VERBOSE_MAKEFILE=1")
 #set(CMAKE_VERBOSE_MAKEFILE 1)

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -114,7 +114,7 @@ include(GNUInstallDirs)
 # Hierarchically copy headers to the install dir
 install (
     DIRECTORY
-        "${CMAKE_CURRENT_SOURCE_DIR}/include/linear_algebra"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/"
     DESTINATION
         ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN


### PR DESCRIPTION
This pull request provides the Linear Algebra library with a Conan package.  This allows users of the library to quickly add it to the project as a dependency via one line in their projects conanfile.txt/conanfile.py: https://docs.conan.io/en/latest/getting_started.html#getting-started

This should also address some of your previous concerns around the upgrade to CMake 3.14.  That is because even though we use CMake 3.14 to build the Linear Algebra library, the test package folder which exists only to verify the Conan package works is actually built requiring only CMake 3.0.  Users of the library depend on the automatically generated CMake targets which do no use advanced features and do not expose a CMake version requirement to users of the library.

As for users wishing to build the library who have an older version of CMake, they can build the library via Conan.  If you look at the Travis and Appveyor files you'll see they add a build requirement upon CMake 3.14.  A build requirement causes Conan to pull down a version of the application to a temporary folder (<user home>/.conan/data/) and then builds the application via this.

Once submitted some environment variables will need to be set on Travis and Appveyor in order for the packages to be automatically uploaded.  I'll provide details of these shortly once I've set these up locally for my copy of the repository on Travis/Appveyor.