### PR TITLE
Investigate the ARM travis failures of GTest, and the Windows build errors

### DIFF
--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -13,3 +13,10 @@ add_executable(test_linear_algebra
 )
 
 target_link_libraries(test_linear_algebra PRIVATE wg21_linear_algebra::wg21_linear_algebra)
+
+enable_testing()
+add_test(
+        NAME test_linear_algebra
+        COMMAND test_linear_algebra
+        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ osx: &osx
   language: generic
 matrix:
   include:
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc9-armv7hf
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc9-armv8
+      # Test detection and unit tests fail due to cross-compiling environment.
+      #- <<: *linux
+      #  env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv7hf CONAN_DOCKER_IMAGE=conanio/gcc9-armv7hf
+      #- <<: *linux
+      #  env: CONAN_GCC_VERSIONS=9 CONAN_ARCHS=armv8 CONAN_DOCKER_IMAGE=conanio/gcc9-armv8
       - <<: *linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
       - <<: *linux
@@ -31,12 +32,12 @@ matrix:
         env: CONAN_CLANG_VERSIONS=8 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=9 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=conanio/clang9
-      # - <<: *osx
-        # osx_image: xcode10.3
-        # env: CONAN_APPLE_CLANG_VERSIONS=10.0
-      # - <<: *osx
-        # osx_image: xcode11.2
-        # env: CONAN_APPLE_CLANG_VERSIONS=11.0
+      - <<: *osx
+        osx_image: xcode10.3
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0
+      - <<: *osx
+        osx_image: xcode11.2
+        env: CONAN_APPLE_CLANG_VERSIONS=11.0
 
 install:
   - ./.travis/install.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -19,7 +19,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     pyenv activate conan
 fi
 
-pip install conan --upgrade
-pip install conan_package_tools==0.30.2
+pip install conan_package_tools --upgrade
 
 conan user

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -13,8 +13,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         eval "$(pyenv init -)"
     fi
 
-    pyenv install 2.7.10
-    pyenv virtualenv 2.7.10 conan
+    pyenv install 3.8.0
+    pyenv virtualenv 3.8.0 conan
     pyenv rehash
     pyenv activate conan
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 build: false
 
 environment:
+  APPVEYOR_RDP_PASSWORD: Testing#123
   CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"
@@ -30,3 +31,6 @@ install:
 
 test_script:
   - python .conan/build.py
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 build: false
 
 environment:
-  #APPVEYOR_RDP_PASSWORD: Testing123
   CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"
@@ -31,6 +30,3 @@ install:
 
 test_script:
   - python .conan/build.py
-
-#on_finish:
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 environment:
-  APPVEYOR_RDP_PASSWORD: Testing123
+  #APPVEYOR_RDP_PASSWORD: Testing123
   CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"
@@ -32,5 +32,5 @@ install:
 test_script:
   - python .conan/build.py
 
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 environment:
-  APPVEYOR_RDP_PASSWORD: Testing#123
+  APPVEYOR_RDP_PASSWORD: Testing123
   CONAN_BUILD_REQUIRES: "cmake_installer/3.14.7@conan/stable"
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,6 +27,8 @@ class LinearAlgebraConan(ConanFile):
 
     def build(self):
         self.cmake.build()
+        if tools.cross_building(self.settings):
+            return
         self.cmake.test()
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,7 @@ class LinearAlgebraConan(ConanFile):
     topics = ("conan", "linear algebra", "header-only", "std", "math", "wg21")
     exports_sources = "*.txt", "*.hpp", "*.cpp", "*.cmake", "*.cmake.in", "LICENSE.txt"
     generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
 
     _cmake = None
     @property
@@ -23,7 +24,6 @@ class LinearAlgebraConan(ConanFile):
             })
             self._cmake.configure(source_folder=os.path.join("linear_algebra", "code"))
         return self._cmake
-
 
     def build(self):
         self.cmake.build()

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -181,16 +181,16 @@ if (${BUILD_TESTING})
     endif(ENABLE_SANITIZERS)
 
     include(CTest)
-    add_test(LA_TEST la_test COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/la_test" WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-
     enable_testing()
-    include(GoogleTest)
-    gtest_discover_tests(la_test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} DISCOVERY_TIMEOUT 30)
+#   This runs GTest to discover tests.  However, that fails in a cross-compiled situation (i.e. compiling ARM code on x86)
+#   We need to set the tests up to run via an ARM emulator in this case to get this working.
+#    include(GoogleTest)
+#    gtest_discover_tests(la_test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} DISCOVERY_TIMEOUT 30)
     #set_tests_properties(la_test PROPERTIES TIMEOUT 10)
     add_test(
-            NAME la_test
-            COMMAND la_test
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        NAME la_test
+        COMMAND la_test
+        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
     )
 endif(${BUILD_TESTING})
 
@@ -218,7 +218,6 @@ install(
 install(
     EXPORT wg21_linear_algebra-target
     NAMESPACE wg21_linear_algebra::
-    #FILE wg21_linear_algebra-target.cmake
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/wg21_linear_algebra"
 )
 

--- a/linear_algebra/code/CMakeLists.txt
+++ b/linear_algebra/code/CMakeLists.txt
@@ -182,16 +182,8 @@ if (${BUILD_TESTING})
 
     include(CTest)
     enable_testing()
-#   This runs GTest to discover tests.  However, that fails in a cross-compiled situation (i.e. compiling ARM code on x86)
-#   We need to set the tests up to run via an ARM emulator in this case to get this working.
-#    include(GoogleTest)
-#    gtest_discover_tests(la_test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} DISCOVERY_TIMEOUT 30)
-    #set_tests_properties(la_test PROPERTIES TIMEOUT 10)
-    add_test(
-        NAME la_test
-        COMMAND la_test
-        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-    )
+    include(GoogleTest)
+    gtest_discover_tests(la_test WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} DISCOVERY_TIMEOUT 30)
 endif(${BUILD_TESTING})
 
 include(GNUInstallDirs)


### PR DESCRIPTION
There were 3 separate issues going on here:

- Cross-compiling for ARM on Linux x86/x64 builds were failing.  This is because to discover tests the GTest CMake layer was running the test executable (built for a different instruction set, i.e. ARM on the underlying x86 host architecture) to get the list of tests.  However, to get this working correctly this needs to be run through an emulator.  For now, I've disabled these packages.  If we need them I'll re-enable them with the tests disabled or look into setting up the emulator on Travis boxes
- Mac builds were failing to when trying to install the PyEnv environment for 2.7.  I've seen this before, I forget the exact cause but upgrading to the latest Python 3.8 fixes this.
- Setting attributes were missing from the Conanfile.py script.  I had thought these were not needed as its a header-only library and expected CMake to detect these setting automatically.  However, these setting are detected automatically by CMake but earlier in the process.  Then these attributes cause the properties to propagate.  If they are missing the fact the compiler was Visual Studio did not propagate.  When Conan runs the tests it looks for the tests target to run.  It turns out that CMake calls this target different things depending on whether its a multi-configuration build (i.e. Visual Studio or XCode) or now (i.e. make).  In this case, it believed it was a single configuration build so tried to run the "test" target and failed.  However, because it really was a multi-configuration build the tests target was instead called "RUN_TESTS".  Who knew?  Well, I do now, but it took some head-scratching to get to the bottom of.