### PR TITLE
Fix include order issue for MaxOS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=9 CONAN_ARCHS=x86_64 CONAN_DOCKER_IMAGE=conanio/clang9
       - <<: *osx
-        osx_image: xcode10.3
-        env: CONAN_APPLE_CLANG_VERSIONS=10.0
-      - <<: *osx
         osx_image: xcode11.2
         env: CONAN_APPLE_CLANG_VERSIONS=11.0
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,7 @@ class LinearAlgebraConan(ConanFile):
     def build_requirements(self):
         # Ensure the package is build against a version of CMake from 3.14 onwards.
         if CMake.get_version() < Version("3.14"):
-            self.build_requires("cmake_installer/3.14.7@conan/stable")
+            self.build_requires("cmake/3.17.0")
 
     _cmake = None
     @property

--- a/linear_algebra/code/include/linear_algebra.hpp
+++ b/linear_algebra/code/include/linear_algebra.hpp
@@ -24,6 +24,10 @@
 #define STD_LA      std::experimental::math
 #define USING_STD   using namespace std::experimental;
 
+#if __has_include(<version>)
+    #include <version>      //- Included first due to possible libc++ bug on Xcode 11
+#endif
+
 #include <cstdint>
 #include <complex>
 #include <initializer_list>

--- a/linear_algebra/code/test/test_common.hpp
+++ b/linear_algebra/code/test/test_common.hpp
@@ -1,6 +1,10 @@
 #ifndef LA_TEST_COMMON_HPP_DEFINED
 #define LA_TEST_COMMON_HPP_DEFINED
 
+#if __has_include(<version>)
+    #include <version>      //- Included first due to possible libc++ bug on Xcode 11
+#endif
+
 #include <iostream>
 #include <iomanip>
 #include <string_view>


### PR DESCRIPTION
Fixing up a branch containing the stable changes of the R6 so that I can tag the release and publish a stable Conan package.