### PR TITLE
Re-enable building from head of MDSpan now MacOS issues are fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,7 @@ cmake_dependent_option(LA_BUILD_DEB "Create a DEB" ON "LA_BUILD_PACKAGE" OFF)
 cmake_dependent_option(LA_BUILD_RPM "Create a RPM" ON "LA_BUILD_PACKAGE" OFF)
 
 option(MDSPAN_ENABLE_CONCEPTS "" OFF)
-FetchContent_Declare(mdspan
-    GIT_REPOSITORY https://github.com/kokkos/mdspan.git 
-    GIT_TAG ebf88178354eebd578e11eecc6cd1d43e282d7b3 #fix-clang-apple-c++17+
-)
+FetchContent_Declare(mdspan GIT_REPOSITORY https://github.com/kokkos/mdspan.git)
 FetchContent_MakeAvailable(mdspan)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
std::mdspan issues for MacOS have been fixed: https://github.com/kokkos/mdspan/pull/29.  As such I am re-enabling building against head revision of master.
