### PR TITLE
In Conan builds MDSpan comes from Conan center.  Only fetch when not under Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
 elseif(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup()
+else()
+    FetchContent_Declare(mdspan GIT_REPOSITORY https://github.com/kokkos/mdspan.git GIT_TAG stable)
+    FetchContent_MakeAvailable(mdspan)
 endif()
 
 
@@ -31,9 +34,6 @@ cmake_dependent_option(LA_BUILD_DEB "Create a DEB" ON "LA_BUILD_PACKAGE" OFF)
 cmake_dependent_option(LA_BUILD_RPM "Create a RPM" ON "LA_BUILD_PACKAGE" OFF)
 
 option(MDSPAN_ENABLE_CONCEPTS "" OFF)
-FetchContent_Declare(mdspan GIT_REPOSITORY https://github.com/kokkos/mdspan.git GIT_TAG stable)
-FetchContent_MakeAvailable(mdspan)
-
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ endif()
 
 project(wg21_linear_algebra VERSION 0.7.0)
 
+include(CTest)
+include(FetchContent)
+include(GNUInstallDirs)
+include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
+
 if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
     conan_basic_setup()
@@ -16,13 +22,6 @@ else()
     FetchContent_Declare(mdspan GIT_REPOSITORY https://github.com/kokkos/mdspan.git GIT_TAG stable)
     FetchContent_MakeAvailable(mdspan)
 endif()
-
-
-include(CTest)
-include(FetchContent)
-include(GNUInstallDirs)
-include(CMakeDependentOption)
-include(CMakePackageConfigHelpers)
 
 option(LA_BUILD_USING_PCH "Build using precompiled headers" OFF)
 option(LA_VERBOSE_TEST_OUTPUT "Write verbose test results" OFF)

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class LinearAlgebraConan(ConanFile):
     topics = ("conan", "linear algebra", "header-only", "std", "math", "wg21")
     exports_sources = "*.txt", "*.hpp", "*.cpp", "*.cmake", "*.cmake.in", "LICENSE.txt"
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake_paths"
     requires = ("mdspan/0.1.0")
 
     def set_version(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class LinearAlgebraConan(ConanFile):
     exports_sources = "*.txt", "*.hpp", "*.cpp", "*.cmake", "*.cmake.in", "LICENSE.txt"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+    requires = ("mdspan/0.1.0")
 
     def set_version(self):
         content = load(os.path.join(os.path.dirname(__file__), "CMakeLists.txt"))


### PR DESCRIPTION
This change prepared the wg21 LA repo to be built as an official package on the Conan Center official package repository for stable releases.  This ensures that when build built under Conan the repo avoids fetching the mdspan repo via Git and instead fetches the official package from the Conan Center.

This will make the wg21 LA Conan package available to a wider audience.