### PR TITLE
update FetchContent gtest to use main branch

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ option(INSTALL_GTEST "" OFF)
 option(gtest_force_shared_crt "" ON)
 add_compile_options(-U__cpp_char8_t)
 
-FetchContent_Declare(gtest GIT_REPOSITORY https://github.com/google/googletest.git)
+FetchContent_Declare(gtest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG main)
 FetchContent_MakeAvailable(gtest)
 
 if(LA_BUILD_USING_PCH)


### PR DESCRIPTION
no GIT_TAG specified, cmake will assume a master branch. build fails, because gtest renamed master to main