### PR TITLE
Move to multi-dimensional operator[]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,13 @@ target_sources(wg21_linear_algebra
 
 target_compile_features(wg21_linear_algebra
     INTERFACE
-        cxx_std_20
+        cxx_std_23
 )
 
-#target_compile_definitions(wg21_linear_algebra
-#    INTERFACE
-#        LA_USE_MDSPAN
-#)
+target_compile_definitions(wg21_linear_algebra
+    INTERFACE
+        MDSPAN_USE_BRACKET_OPERATOR
+)
 
 target_link_libraries(wg21_linear_algebra
     INTERFACE

--- a/tests/test_mse_2B.cpp
+++ b/tests/test_mse_2B.cpp
@@ -594,15 +594,15 @@ TEST(MSE_Matrix_2B, Span)
 
     //- The elements of the const and mutable spans should have the expected values.
     //
-    EXPECT_EQ(sp1(0, 0), 11.0f);
-    EXPECT_EQ(sp1(0, 1), 12.0f);
-    EXPECT_EQ(sp1(0, 2), 13.0f);
-    EXPECT_EQ(sp1(0, 3), 14.0f);
+    EXPECT_EQ((sp1[0, 0]), 11.0f);
+    EXPECT_EQ((sp1[0, 1]), 12.0f);
+    EXPECT_EQ((sp1[0, 2]), 13.0f);
+    EXPECT_EQ((sp1[0, 3]), 14.0f);
 
-    EXPECT_EQ(csp1(0, 0), 11.0f);
-    EXPECT_EQ(csp1(0, 1), 12.0f);
-    EXPECT_EQ(csp1(0, 2), 13.0f);
-    EXPECT_EQ(csp1(0, 3), 14.0f);
+    EXPECT_EQ((csp1[0, 0]), 11.0f);
+    EXPECT_EQ((csp1[0, 1]), 12.0f);
+    EXPECT_EQ((csp1[0, 2]), 13.0f);
+    EXPECT_EQ((csp1[0, 3]), 14.0f);
 
     //- Whole-object comparison between engines and spans should work as expected.
     //

--- a/tests/test_mse_3A.cpp
+++ b/tests/test_mse_3A.cpp
@@ -594,15 +594,15 @@ TEST(MSE_Matrix_3A, Span)
 
     //- The elements of the const and mutable spans should have the expected values.
     //
-    EXPECT_EQ(sp1(0, 0), 11.0f);
-    EXPECT_EQ(sp1(1, 0), 12.0f);
-    EXPECT_EQ(sp1(2, 0), 13.0f);
-    EXPECT_EQ(sp1(3, 0), 14.0f);
+    EXPECT_EQ((sp1[0, 0]), 11.0f);
+    EXPECT_EQ((sp1[1, 0]), 12.0f);
+    EXPECT_EQ((sp1[2, 0]), 13.0f);
+    EXPECT_EQ((sp1[3, 0]), 14.0f);
 
-    EXPECT_EQ(csp1(0, 0), 11.0f);
-    EXPECT_EQ(csp1(1, 0), 12.0f);
-    EXPECT_EQ(csp1(2, 0), 13.0f);
-    EXPECT_EQ(csp1(3, 0), 14.0f);
+    EXPECT_EQ((csp1[0, 0]), 11.0f);
+    EXPECT_EQ((csp1[1, 0]), 12.0f);
+    EXPECT_EQ((csp1[2, 0]), 13.0f);
+    EXPECT_EQ((csp1[3, 0]), 14.0f);
 
     //- Whole-object comparison between engines and spans should work as expected.
     //
@@ -615,10 +615,10 @@ TEST(MSE_Matrix_3A, Span)
 
     //- Setting values of individual span elements should be reflected in the owning engine.
     //
-    sp1(0, 0) = 111.0f;
-    sp1(1, 0) = 222.0f;
-    sp1(2, 0) = 333.0f;
-    sp1(3, 0) = 444.0f;
+    sp1[0, 0] = 111.0f;
+    sp1[1, 0] = 222.0f;
+    sp1[2, 0] = 333.0f;
+    sp1[3, 0] = 444.0f;
     EXPECT_EQ(e1(0), 111.0f);
     EXPECT_EQ(e1(1), 222.0f);
     EXPECT_EQ(e1(2), 333.0f);

--- a/tests/test_mse_4B.cpp
+++ b/tests/test_mse_4B.cpp
@@ -552,39 +552,39 @@ TEST(MSE_Matrix_4B, Span)
 
     //- The elements of the const and mutable spans should have the expected values.
     //
-    EXPECT_EQ(sp1(0, 0), 11.0f);
-    EXPECT_EQ(sp1(0, 1), 12.0f);
-    EXPECT_EQ(sp1(0, 2), 13.0f);
-    EXPECT_EQ(sp1(0, 3), 14.0f);
-    EXPECT_EQ(sp1(1, 0), 21.0f);
-    EXPECT_EQ(sp1(1, 1), 22.0f);
-    EXPECT_EQ(sp1(1, 2), 23.0f);
-    EXPECT_EQ(sp1(1, 3), 24.0f);
-    EXPECT_EQ(sp1(2, 0), 31.0f);
-    EXPECT_EQ(sp1(2, 1), 32.0f);
-    EXPECT_EQ(sp1(2, 2), 33.0f);
-    EXPECT_EQ(sp1(2, 3), 34.0f);
-    EXPECT_EQ(sp1(3, 0), 41.0f);
-    EXPECT_EQ(sp1(3, 1), 42.0f);
-    EXPECT_EQ(sp1(3, 2), 43.0f);
-    EXPECT_EQ(sp1(3, 3), 44.0f);
+    EXPECT_EQ((sp1[0, 0]), 11.0f);
+    EXPECT_EQ((sp1[0, 1]), 12.0f);
+    EXPECT_EQ((sp1[0, 2]), 13.0f);
+    EXPECT_EQ((sp1[0, 3]), 14.0f);
+    EXPECT_EQ((sp1[1, 0]), 21.0f);
+    EXPECT_EQ((sp1[1, 1]), 22.0f);
+    EXPECT_EQ((sp1[1, 2]), 23.0f);
+    EXPECT_EQ((sp1[1, 3]), 24.0f);
+    EXPECT_EQ((sp1[2, 0]), 31.0f);
+    EXPECT_EQ((sp1[2, 1]), 32.0f);
+    EXPECT_EQ((sp1[2, 2]), 33.0f);
+    EXPECT_EQ((sp1[2, 3]), 34.0f);
+    EXPECT_EQ((sp1[3, 0]), 41.0f);
+    EXPECT_EQ((sp1[3, 1]), 42.0f);
+    EXPECT_EQ((sp1[3, 2]), 43.0f);
+    EXPECT_EQ((sp1[3, 3]), 44.0f);
 
-    EXPECT_EQ(csp1(0, 0), 11.0f);
-    EXPECT_EQ(csp1(0, 1), 12.0f);
-    EXPECT_EQ(csp1(0, 2), 13.0f);
-    EXPECT_EQ(csp1(0, 3), 14.0f);
-    EXPECT_EQ(csp1(1, 0), 21.0f);
-    EXPECT_EQ(csp1(1, 1), 22.0f);
-    EXPECT_EQ(csp1(1, 2), 23.0f);
-    EXPECT_EQ(csp1(1, 3), 24.0f);
-    EXPECT_EQ(csp1(2, 0), 31.0f);
-    EXPECT_EQ(csp1(2, 1), 32.0f);
-    EXPECT_EQ(csp1(2, 2), 33.0f);
-    EXPECT_EQ(csp1(2, 3), 34.0f);
-    EXPECT_EQ(csp1(3, 0), 41.0f);
-    EXPECT_EQ(csp1(3, 1), 42.0f);
-    EXPECT_EQ(csp1(3, 2), 43.0f);
-    EXPECT_EQ(csp1(3, 3), 44.0f);
+    EXPECT_EQ((csp1[0, 0]), 11.0f);
+    EXPECT_EQ((csp1[0, 1]), 12.0f);
+    EXPECT_EQ((csp1[0, 2]), 13.0f);
+    EXPECT_EQ((csp1[0, 3]), 14.0f);
+    EXPECT_EQ((csp1[1, 0]), 21.0f);
+    EXPECT_EQ((csp1[1, 1]), 22.0f);
+    EXPECT_EQ((csp1[1, 2]), 23.0f);
+    EXPECT_EQ((csp1[1, 3]), 24.0f);
+    EXPECT_EQ((csp1[2, 0]), 31.0f);
+    EXPECT_EQ((csp1[2, 1]), 32.0f);
+    EXPECT_EQ((csp1[2, 2]), 33.0f);
+    EXPECT_EQ((csp1[2, 3]), 34.0f);
+    EXPECT_EQ((csp1[3, 0]), 41.0f);
+    EXPECT_EQ((csp1[3, 1]), 42.0f);
+    EXPECT_EQ((csp1[3, 2]), 43.0f);
+    EXPECT_EQ((csp1[3, 3]), 44.0f);
 
     //- Whole-object comparison between engines and spans should work as expected.
     //


### PR DESCRIPTION
Upgrade msdpan access to use the C++23 enable multi-dimensional `operator[]` instead of the kokkos::mdspan specific `operator()`.